### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Adium Shell
 ===========
 
-.. image:: https://pypip.in/v/adium-sh/badge.png
+.. image:: https://img.shields.io/pypi/v/adium-sh.svg
         :target: https://pypi.python.org/pypi/adium-sh
 
 Adium Shell (adium-sh) is a command-line tool and Python wrapper for Adium.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20adium-sh))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `adium-sh`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.